### PR TITLE
Fix/windows cmake

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+arbor/include/git-source-id text eol=lf

--- a/arbor/include/CMakeLists.txt
+++ b/arbor/include/CMakeLists.txt
@@ -66,7 +66,7 @@ string(TOUPPER "${CMAKE_BUILD_TYPE}" arb_config_str)
 add_custom_command(
     OUTPUT version.hpp-test
     DEPENDS _always_rebuild
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/git-source-id ${FULL_VERSION_STRING} ${ARB_ARCH} ${arb_config_str} ${arb_features} > version.hpp-test
+    COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/git-source-id ${FULL_VERSION_STRING} ${ARB_ARCH} ${arb_config_str} ${arb_features} > version.hpp-test
 )
 
 set(version_hpp_path arbor/version.hpp)

--- a/arbor/include/CMakeLists.txt
+++ b/arbor/include/CMakeLists.txt
@@ -66,7 +66,7 @@ string(TOUPPER "${CMAKE_BUILD_TYPE}" arb_config_str)
 add_custom_command(
     OUTPUT version.hpp-test
     DEPENDS _always_rebuild
-    COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/git-source-id ${FULL_VERSION_STRING} ${ARB_ARCH} ${arb_config_str} ${arb_features} > version.hpp-test
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/git-source-id ${FULL_VERSION_STRING} ${ARB_ARCH} ${arb_config_str} ${arb_features} > version.hpp-test
 )
 
 set(version_hpp_path arbor/version.hpp)


### PR DESCRIPTION
### Description

The changes in this pull request involve adding a `.gitattributes` file with the specified content `arbor/include/git-source-id text eol=lf`.

- Added a `.gitattributes` file with the content `arbor/include/git-source-id text eol=lf`.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a `.gitattributes` file to enforce LF line endings for `arbor/include/git-source-id`.

### Why are these changes being made?

This change ensures consistent line endings across different operating systems, particularly addressing issues on Windows where default line endings can differ, potentially causing build or runtime errors. By specifying `eol=lf`, we maintain uniformity and prevent related issues.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->